### PR TITLE
fix: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+.github
+examples
+node_nodules
+src
+test
+.eslintignore
+.eslintrc
+.gitignore
+API.md
+CODEOWNERS
+jest.config.js
+package-lock.json
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "files": [
+    "/lib",
+    "./README.md",
+    "./LICENSE"
+  ],
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch",


### PR DESCRIPTION
**Description**

- having .npmignore may resolve the npm package issue. (currently, it publishes the whole project without `./lib`)
