### PR TITLE
fix: add pre-publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "generate:assets": "npm run build && npm run docs && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "release": "semantic-release"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate:readme:toc": "markdown-toc -i README.md",
     "generate:assets": "npm run build && npm run docs && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "release": "semantic-release"
+    "release": "semantic-release",
     "prepublishOnly": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
**Description**

- we need `prepublishOnly` script to generate `./lib` for npm package.
Resolves #52 