### PR TITLE
chore: update bot name in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @KhudaDad414 @magicmatatjahu @derberg @github-actions[bot]
+* @KhudaDad414 @magicmatatjahu @derberg @asyncapi-bot-eve


### PR DESCRIPTION
updating` @github-actions[bot]` to `@asyncapi-bot-eve` in CODEOWNERS file.

**Related issue(s)**
https://github.com/asyncapi/community/issues/275