### PR TITLE
feat: rename flag `moveToComponents` -> `moveDuplicatesToComponents`

### DIFF
--- a/API.md
+++ b/API.md
@@ -132,7 +132,7 @@ Converts JSON or YAML string object.
 | --- | --- | --- |
 | [reuseComponents] | <code>Boolean</code> | whether to reuse components from `components` section or not. Defaults to `true`. |
 | [removeComponents] | <code>Boolean</code> | whether to remove un-used components from `components` section or not. Defaults to `true`. |
-| [moveToComponents] | <code>Boolean</code> | whether to move duplicated components to the `components` section or not. Defaults to `true`. |
+| [moveDuplicatesToComponents] | <code>Boolean</code> | whether to move duplicated components to the `components` section or not. Defaults to `true`. |
 
 <a name="Options"></a>
 
@@ -144,4 +144,3 @@ Converts JSON or YAML string object.
 | --- | --- | --- |
 | [rules] | [<code>Rules</code>](#Rules) | the list of rules that specifies which type of optimizations should be applied. |
 | [output] | <code>String</code> | specifies which type of output user wants, `'JSON'` or `'YAML'`. Defaults to `'YAML'`; |
-

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ the report value will be:
       action: 'remove',
     }
   ],
-  moveToComponents: [
+  moveDuplicatesToComponents: [
     {
       //move will ref the current path to the moved component as well.
       path: 'channels.smartylighting/event/{streetlightId}/lighting/measured.parameters.streetlightId',
@@ -159,7 +159,7 @@ const optimizedDocument = optimizer.getOptimizedDocument({
   rules: {
     reuseComponents: true,
     removeComponents: true,
-    moveToComponents: true 
+    moveDuplicatesToComponents: true 
   }
 });
 /*

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,7 +11,7 @@ optimizer.getReport().then((report) => {
     rules: {
       reuseComponents: true,
       removeComponents: true,
-      moveToComponents: true,
+      moveDuplicatesToComponents: true,
     },
   })
   //store optimizedDocument as to output.yaml

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -7,7 +7,7 @@ import {
   Reporter,
 } from './index.d'
 import { Parser } from '@asyncapi/parser'
-import { removeComponents, reuseComponents, moveToComponents } from './Reporters'
+import { removeComponents, reuseComponents, moveDuplicatesToComponents } from './Reporters'
 import YAML from 'js-yaml'
 import merge from 'merge-deep'
 import * as _ from 'lodash'
@@ -42,7 +42,7 @@ export class Optimizer {
    */
   constructor(private YAMLorJSON: any) {
     this.outputObject = toJS(this.YAMLorJSON)
-    this.reporters = [removeComponents, reuseComponents, moveToComponents]
+    this.reporters = [removeComponents, reuseComponents, moveDuplicatesToComponents]
   }
 
   /**
@@ -78,7 +78,7 @@ export class Optimizer {
    * @typedef {Object} Rules
    * @property {Boolean=} reuseComponents - whether to reuse components from `components` section or not. Defaults to `true`.
    * @property {Boolean=} removeComponents - whether to remove un-used components from `components` section or not. Defaults to `true`.
-   * @property {Boolean=} moveToComponents - whether to move duplicated components to the `components` section or not. Defaults to `true`.
+   * @property {Boolean=} moveDuplicatesToComponents - whether to move duplicated components to the `components` section or not. Defaults to `true`.
    */
 
   /**
@@ -98,7 +98,7 @@ export class Optimizer {
       rules: {
         reuseComponents: true,
         removeComponents: true,
-        moveToComponents: true,
+        moveDuplicatesToComponents: true,
       },
       output: Output.YAML,
     }

--- a/src/Reporters/index.ts
+++ b/src/Reporters/index.ts
@@ -1,3 +1,3 @@
-export * from './MoveToComponents'
+export * from './moveDuplicatesToComponents'
 export * from './RemoveComponents'
 export * from './ReuseComponents'

--- a/src/Reporters/moveDuplicatesToComponents.ts
+++ b/src/Reporters/moveDuplicatesToComponents.ts
@@ -2,7 +2,7 @@ import { Action } from '../Optimizer'
 import { createReport, isEqual, isInComponents } from '../Utils'
 import { OptimizableComponent, OptimizableComponentGroup, ReportElement, Reporter } from 'index.d'
 import Debug from 'debug'
-const debug = Debug('reporter:moveToComponents')
+const debug = Debug('reporter:moveDuplicatesToComponents')
 /**
  *
  * @param optimizableComponentGroup components that you want to analyze for duplicates.
@@ -58,8 +58,8 @@ const findDuplicateComponents = (
   return resultElements
 }
 
-export const moveToComponents: Reporter = (optimizableComponentsGroup) => {
-  return createReport(findDuplicateComponents, optimizableComponentsGroup, 'moveToComponents')
+export const moveDuplicatesToComponents: Reporter = (optimizableComponentsGroup) => {
+  return createReport(findDuplicateComponents, optimizableComponentsGroup, 'moveDuplicatesToComponents')
 }
 
 function getOutsideComponents(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export type OptimizableComponentGroup = {
 export interface Report {
   reuseComponents?: ReportElement[]
   removeComponents?: ReportElement[]
-  moveToComponents?: ReportElement[]
+  moveDuplicatesToComponents?: ReportElement[]
 }
 
 //In the next major version we can rename this to `Report` and use this format instead.
@@ -32,7 +32,7 @@ export type Reporter = (optimizeableComponents: OptimizableComponentGroup[]) => 
 interface Rules {
   reuseComponents?: boolean
   removeComponents?: boolean
-  moveToComponents?: boolean
+  moveDuplicatesToComponents?: boolean
 }
 export interface Options {
   rules?: Rules

--- a/test/Reporters/Reporters.spec.ts
+++ b/test/Reporters/Reporters.spec.ts
@@ -1,10 +1,10 @@
-import { moveToComponents, reuseComponents, removeComponents } from '../../src/Reporters'
+import { moveDuplicatesToComponents, reuseComponents, removeComponents } from '../../src/Reporters'
 import { inputYAML } from '../fixtures'
 import { Parser } from '@asyncapi/parser'
 import { getOptimizableComponents } from '../../src/ComponentProvider'
 import { OptimizableComponentGroup } from '../../src/index.d'
 
-const MoveToComponentsExpectedResult: any[] = [
+const moveDuplicatesToComponentsExpectedResult: any[] = [
   {
     path: 'channels.withDuplicatedMessage1.messages.duped1',
     action: 'move',
@@ -55,11 +55,11 @@ describe('Optimizers', () => {
     const asyncapiDocument = await new Parser().parse(inputYAML, { applyTraits: false })
     optimizableComponents = getOptimizableComponents(asyncapiDocument.document!)
   })
-  describe('MoveToComponents', () => {
+  describe('moveDuplicatesToComponents', () => {
     test('should contain the correct optimizations.', () => {
-      const report = moveToComponents(optimizableComponents)
-      expect(report.elements).toEqual(MoveToComponentsExpectedResult)
-      expect(report.type).toEqual('moveToComponents')
+      const report = moveDuplicatesToComponents(optimizableComponents)
+      expect(report.elements).toEqual(moveDuplicatesToComponentsExpectedResult)
+      expect(report.type).toEqual('moveDuplicatesToComponents')
     })
   })
 


### PR DESCRIPTION
This PR renames flag `moveToComponents` -> `moveDuplicatesToComponents`.

Partial resolution of https://github.com/asyncapi/bundler/issues/141