### PR TITLE
fix: add searching for `replyAddresses` component of v3

### DIFF
--- a/src/ComponentProvider.ts
+++ b/src/ComponentProvider.ts
@@ -74,6 +74,7 @@ export const getOptimizableComponents = (
     parameters: getAllComponents('parameters'),
     correlationIds: getAllComponents('correlationIds'),
     replies: getAllComponents('replies'),
+    replyAddresses: getAllComponents('replyAddresses'),
     externalDocs: getAllComponents('externalDocs'),
     tags: getAllComponents('tags'),
     operationTraits: getAllComponents('operationTraits'),


### PR DESCRIPTION
This PR adds searching for `replyAddresses` component of v3.

Partial resolution of https://github.com/asyncapi/bundler/issues/141