### PR TITLE
chore: remove JSON.stringify() from example code

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -5,7 +5,7 @@ const { Optimizer } = require('../lib/Optimizer')
 const input = require('fs').readFileSync('./examples/input.yaml', 'utf8')
 const optimizer = new Optimizer(input)
 optimizer.getReport().then((report) => {
-  console.log(JSON.stringify(report))
+  console.log(report)
   const optimizedDocument = optimizer.getOptimizedDocument({
     output: 'YAML',
     rules: {


### PR DESCRIPTION
This PR removes unneeded `JSON.stringify()` from the example code.