### PR TITLE
feat: rename flag move to components to move duplicates to components

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,9 +26,9 @@ jobs:
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
       - if: steps.packagejson.outputs.exists == 'true'
         name: Bumping latest version of this package in other repositories
-        uses: derberg/npm-dependency-manager-for-your-github-org@26a4f13d740254719971325046822a169aaa7441 # using v5.-.- https://github.com/derberg/npm-dependency-manager-for-your-github-org/releases/tag/v5.0.0
+        uses: derberg/npm-dependency-manager-for-your-github-org@3df56be95bcaa5c76a9c9a4af863ab151545b649 # using v6.-.- https://github.com/derberg/npm-dependency-manager-for-your-github-org/releases/tag/v6
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          repos_to_ignore: spec,bindings
+          repos_to_ignore: spec,bindings,saunter

--- a/API.md
+++ b/API.md
@@ -132,7 +132,7 @@ Converts JSON or YAML string object.
 | --- | --- | --- |
 | [reuseComponents] | <code>Boolean</code> | whether to reuse components from `components` section or not. Defaults to `true`. |
 | [removeComponents] | <code>Boolean</code> | whether to remove un-used components from `components` section or not. Defaults to `true`. |
-| [moveToComponents] | <code>Boolean</code> | whether to move duplicated components to the `components` section or not. Defaults to `true`. |
+| [moveDuplicatesToComponents] | <code>Boolean</code> | whether to move duplicated components to the `components` section or not. Defaults to `true`. |
 
 <a name="Options"></a>
 
@@ -144,4 +144,3 @@ Converts JSON or YAML string object.
 | --- | --- | --- |
 | [rules] | [<code>Rules</code>](#Rules) | the list of rules that specifies which type of optimizations should be applied. |
 | [output] | <code>String</code> | specifies which type of output user wants, `'JSON'` or `'YAML'`. Defaults to `'YAML'`; |
-

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ the report value will be:
       action: 'remove',
     }
   ],
-  moveToComponents: [
+  moveDuplicatesToComponents: [
     {
       //move will ref the current path to the moved component as well.
       path: 'channels.smartylighting/event/{streetlightId}/lighting/measured.parameters.streetlightId',
@@ -159,7 +159,7 @@ const optimizedDocument = optimizer.getOptimizedDocument({
   rules: {
     reuseComponents: true,
     removeComponents: true,
-    moveToComponents: true 
+    moveDuplicatesToComponents: true 
   }
 });
 /*

--- a/examples/index.js
+++ b/examples/index.js
@@ -5,7 +5,7 @@ const { Optimizer } = require('../lib/Optimizer')
 const input = require('fs').readFileSync('./examples/input.yaml', 'utf8')
 const optimizer = new Optimizer(input)
 optimizer.getReport().then((report) => {
-  console.log(JSON.stringify(report))
+  console.log(report)
   const optimizedDocument = optimizer.getOptimizedDocument({
     output: 'YAML',
     rules: {

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,7 +11,7 @@ optimizer.getReport().then((report) => {
     rules: {
       reuseComponents: true,
       removeComponents: true,
-      moveToComponents: true,
+      moveDuplicatesToComponents: true,
     },
   })
   //store optimizedDocument as to output.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.9",
+        "@asyncapi/parser": "^3.0.10",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.9.tgz",
-      "integrity": "sha512-xsuW8UHWwQD8zbGCYirA6gjRkVUL9+RxboQY1Fm+AFlRo9cL9kMQr7OvfduJErI0PEsp/KdkuP56s7izlt5/+A==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.10.tgz",
+      "integrity": "sha512-x9qo7SHGzPWbC1XCRyilcI+Z6UZsWZ9uRl05h9j4G/v+3IjNG3krwngiAbt59nbLlYZD/nBS7Hc03GayoocnQw==",
       "dependencies": {
-        "@asyncapi/specs": "^6.5.2",
+        "@asyncapi/specs": "^6.5.3",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.9.tgz",
-      "integrity": "sha512-xsuW8UHWwQD8zbGCYirA6gjRkVUL9+RxboQY1Fm+AFlRo9cL9kMQr7OvfduJErI0PEsp/KdkuP56s7izlt5/+A==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.10.tgz",
+      "integrity": "sha512-x9qo7SHGzPWbC1XCRyilcI+Z6UZsWZ9uRl05h9j4G/v+3IjNG3krwngiAbt59nbLlYZD/nBS7Hc03GayoocnQw==",
       "requires": {
-        "@asyncapi/specs": "^6.5.2",
+        "@asyncapi/specs": "^6.5.3",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.6",
+        "@asyncapi/parser": "^3.0.7",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.6.tgz",
-      "integrity": "sha512-oHTaeXG9DOdBlBZ90xCSPCl3kT5XE851+Rxn47bMfG05Z48csZ1o9wFUl/SzQt+L8HgplFeQG4n/7EJHYOlcWQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.7.tgz",
+      "integrity": "sha512-CKdkZbhs+2Mw7M2UZPypKEhKuaF+o5qZB2TQc0pDf+Wr09uEnm6WTdyqzmMGVb5fkQYApu8psQeDyVMbhfoWXQ==",
       "dependencies": {
-        "@asyncapi/specs": "^6.4.0",
+        "@asyncapi/specs": "^6.5.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
-      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.0.tgz",
+      "integrity": "sha512-84QUcfMT05+vvHO5EnSI0I5OZKzMgF/i3vgw92ghk1l52VM/lb3qNnuARzyo+uHJ9kmIb5+naK9wTuliVOdzmg==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.6.tgz",
-      "integrity": "sha512-oHTaeXG9DOdBlBZ90xCSPCl3kT5XE851+Rxn47bMfG05Z48csZ1o9wFUl/SzQt+L8HgplFeQG4n/7EJHYOlcWQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.7.tgz",
+      "integrity": "sha512-CKdkZbhs+2Mw7M2UZPypKEhKuaF+o5qZB2TQc0pDf+Wr09uEnm6WTdyqzmMGVb5fkQYApu8psQeDyVMbhfoWXQ==",
       "requires": {
-        "@asyncapi/specs": "^6.4.0",
+        "@asyncapi/specs": "^6.5.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
-      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.0.tgz",
+      "integrity": "sha512-84QUcfMT05+vvHO5EnSI0I5OZKzMgF/i3vgw92ghk1l52VM/lb3qNnuARzyo+uHJ9kmIb5+naK9wTuliVOdzmg==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.2",
+        "@asyncapi/parser": "^3.0.3",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.2.tgz",
-      "integrity": "sha512-AtDFndWwnaqGoXZQY2DRtORT2Ls4BI7MSR+Rg7TRwxf5jxIz/WVvQwc5HElkHuDEkIZslYu+ukFzNq3awdj0aw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.3.tgz",
+      "integrity": "sha512-nRkzgzcSkqBMy6kL/AWNsL8EJzDePFI4x6949V+4R/zYtbAm1IYY9Q4DEc81pnxoWHrJrVvrSD6O73/VTJ+XoA==",
       "dependencies": {
-        "@asyncapi/specs": "^6.2.0",
+        "@asyncapi/specs": "^6.2.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.0.tgz",
-      "integrity": "sha512-5uf/Rg6pavZHx7rVIkP0TP/icIahJCuHgmY1rdtkrWxHZMXbASDDV3DlTUaonbsUeemwchoqljmrTd1O1xqvxg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.1.tgz",
+      "integrity": "sha512-rfd0bzJrApEbxYD4U1SUG02GGG6lK6i6lup9LDWpVu1QwwuMNLAgf8+jsmsf3e7OinB/lauxRumGODXCxBu5Jw==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.2.tgz",
-      "integrity": "sha512-AtDFndWwnaqGoXZQY2DRtORT2Ls4BI7MSR+Rg7TRwxf5jxIz/WVvQwc5HElkHuDEkIZslYu+ukFzNq3awdj0aw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.3.tgz",
+      "integrity": "sha512-nRkzgzcSkqBMy6kL/AWNsL8EJzDePFI4x6949V+4R/zYtbAm1IYY9Q4DEc81pnxoWHrJrVvrSD6O73/VTJ+XoA==",
       "requires": {
-        "@asyncapi/specs": "^6.2.0",
+        "@asyncapi/specs": "^6.2.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.0.tgz",
-      "integrity": "sha512-5uf/Rg6pavZHx7rVIkP0TP/icIahJCuHgmY1rdtkrWxHZMXbASDDV3DlTUaonbsUeemwchoqljmrTd1O1xqvxg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.1.tgz",
+      "integrity": "sha512-rfd0bzJrApEbxYD4U1SUG02GGG6lK6i6lup9LDWpVu1QwwuMNLAgf8+jsmsf3e7OinB/lauxRumGODXCxBu5Jw==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.3",
+        "@asyncapi/parser": "^3.0.4",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.3.tgz",
-      "integrity": "sha512-nRkzgzcSkqBMy6kL/AWNsL8EJzDePFI4x6949V+4R/zYtbAm1IYY9Q4DEc81pnxoWHrJrVvrSD6O73/VTJ+XoA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.4.tgz",
+      "integrity": "sha512-xop2ZGCNey6eaNp6ypscrWCQogC++XAjq7yWvaB9v3GfpL0P8Dq+d29NetlvpLFZ1xnkbeuUg9R2m7FBZYkPFw==",
       "dependencies": {
-        "@asyncapi/specs": "^6.2.1",
+        "@asyncapi/specs": "^6.3.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.1.tgz",
-      "integrity": "sha512-rfd0bzJrApEbxYD4U1SUG02GGG6lK6i6lup9LDWpVu1QwwuMNLAgf8+jsmsf3e7OinB/lauxRumGODXCxBu5Jw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.3.0.tgz",
+      "integrity": "sha512-Ui7Fekd/ruqd4hTSb5ogsTG8eylHEyKR5qKOtg+HwOYWlUEtObOD2UlhbuASiB4YnG5SSfkEKR5YsUJmf/ESYQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.3.tgz",
-      "integrity": "sha512-nRkzgzcSkqBMy6kL/AWNsL8EJzDePFI4x6949V+4R/zYtbAm1IYY9Q4DEc81pnxoWHrJrVvrSD6O73/VTJ+XoA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.4.tgz",
+      "integrity": "sha512-xop2ZGCNey6eaNp6ypscrWCQogC++XAjq7yWvaB9v3GfpL0P8Dq+d29NetlvpLFZ1xnkbeuUg9R2m7FBZYkPFw==",
       "requires": {
-        "@asyncapi/specs": "^6.2.1",
+        "@asyncapi/specs": "^6.3.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.1.tgz",
-      "integrity": "sha512-rfd0bzJrApEbxYD4U1SUG02GGG6lK6i6lup9LDWpVu1QwwuMNLAgf8+jsmsf3e7OinB/lauxRumGODXCxBu5Jw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.3.0.tgz",
+      "integrity": "sha512-Ui7Fekd/ruqd4hTSb5ogsTG8eylHEyKR5qKOtg+HwOYWlUEtObOD2UlhbuASiB4YnG5SSfkEKR5YsUJmf/ESYQ==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.8",
+        "@asyncapi/parser": "^3.0.9",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.8.tgz",
-      "integrity": "sha512-BdH+Or1MjZdoBotz1DkwY6aW3CPWA5fcFMAngmBkviIHhmZqZBn7hA55WQ5YeYbRytct/o2ATtVI/pHbU/wPGg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.9.tgz",
+      "integrity": "sha512-xsuW8UHWwQD8zbGCYirA6gjRkVUL9+RxboQY1Fm+AFlRo9cL9kMQr7OvfduJErI0PEsp/KdkuP56s7izlt5/+A==",
       "dependencies": {
-        "@asyncapi/specs": "^6.5.1",
+        "@asyncapi/specs": "^6.5.2",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.1.tgz",
-      "integrity": "sha512-T7pOyVt7jo3VV3dPVvWwGYde/09WyFa0Qpq8Yjj06UNWJoXACftsdRF/pK0qLtjC0NAB8YV0AlDvxASYiwXq3g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.3.tgz",
+      "integrity": "sha512-mZROlCOLkZEWy5tN4pPop3JEJflSKmLLMGO1TebF5wjnroqZ3yp/GuGUxVIl3jVNxFk1i5nZ2AtWzAD/HaUj3Q==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.8.tgz",
-      "integrity": "sha512-BdH+Or1MjZdoBotz1DkwY6aW3CPWA5fcFMAngmBkviIHhmZqZBn7hA55WQ5YeYbRytct/o2ATtVI/pHbU/wPGg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.9.tgz",
+      "integrity": "sha512-xsuW8UHWwQD8zbGCYirA6gjRkVUL9+RxboQY1Fm+AFlRo9cL9kMQr7OvfduJErI0PEsp/KdkuP56s7izlt5/+A==",
       "requires": {
-        "@asyncapi/specs": "^6.5.1",
+        "@asyncapi/specs": "^6.5.2",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.1.tgz",
-      "integrity": "sha512-T7pOyVt7jo3VV3dPVvWwGYde/09WyFa0Qpq8Yjj06UNWJoXACftsdRF/pK0qLtjC0NAB8YV0AlDvxASYiwXq3g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.3.tgz",
+      "integrity": "sha512-mZROlCOLkZEWy5tN4pPop3JEJflSKmLLMGO1TebF5wjnroqZ3yp/GuGUxVIl3jVNxFk1i5nZ2AtWzAD/HaUj3Q==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.4",
+        "@asyncapi/parser": "^3.0.5",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.4.tgz",
-      "integrity": "sha512-xop2ZGCNey6eaNp6ypscrWCQogC++XAjq7yWvaB9v3GfpL0P8Dq+d29NetlvpLFZ1xnkbeuUg9R2m7FBZYkPFw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.5.tgz",
+      "integrity": "sha512-Kc/hwCyb2/YzcIfQlY9lwjUDV/9cXMjVewQz9WvPVAaFlOr83bdHpccfnl2sQNXDcC+zCcpEDBjs41ATowPE3Q==",
       "dependencies": {
-        "@asyncapi/specs": "^6.3.0",
+        "@asyncapi/specs": "^6.4.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.3.0.tgz",
-      "integrity": "sha512-Ui7Fekd/ruqd4hTSb5ogsTG8eylHEyKR5qKOtg+HwOYWlUEtObOD2UlhbuASiB4YnG5SSfkEKR5YsUJmf/ESYQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
+      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.4.tgz",
-      "integrity": "sha512-xop2ZGCNey6eaNp6ypscrWCQogC++XAjq7yWvaB9v3GfpL0P8Dq+d29NetlvpLFZ1xnkbeuUg9R2m7FBZYkPFw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.5.tgz",
+      "integrity": "sha512-Kc/hwCyb2/YzcIfQlY9lwjUDV/9cXMjVewQz9WvPVAaFlOr83bdHpccfnl2sQNXDcC+zCcpEDBjs41ATowPE3Q==",
       "requires": {
-        "@asyncapi/specs": "^6.3.0",
+        "@asyncapi/specs": "^6.4.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.3.0.tgz",
-      "integrity": "sha512-Ui7Fekd/ruqd4hTSb5ogsTG8eylHEyKR5qKOtg+HwOYWlUEtObOD2UlhbuASiB4YnG5SSfkEKR5YsUJmf/ESYQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
+      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.5",
+        "@asyncapi/parser": "^3.0.6",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.5.tgz",
-      "integrity": "sha512-Kc/hwCyb2/YzcIfQlY9lwjUDV/9cXMjVewQz9WvPVAaFlOr83bdHpccfnl2sQNXDcC+zCcpEDBjs41ATowPE3Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.6.tgz",
+      "integrity": "sha512-oHTaeXG9DOdBlBZ90xCSPCl3kT5XE851+Rxn47bMfG05Z48csZ1o9wFUl/SzQt+L8HgplFeQG4n/7EJHYOlcWQ==",
       "dependencies": {
         "@asyncapi/specs": "^6.4.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -9032,9 +9032,9 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.5.tgz",
-      "integrity": "sha512-Kc/hwCyb2/YzcIfQlY9lwjUDV/9cXMjVewQz9WvPVAaFlOr83bdHpccfnl2sQNXDcC+zCcpEDBjs41ATowPE3Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.6.tgz",
+      "integrity": "sha512-oHTaeXG9DOdBlBZ90xCSPCl3kT5XE851+Rxn47bMfG05Z48csZ1o9wFUl/SzQt+L8HgplFeQG4n/7EJHYOlcWQ==",
       "requires": {
         "@asyncapi/specs": "^6.4.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/optimizer",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^3.0.7",
+        "@asyncapi/parser": "^3.0.8",
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
@@ -38,11 +38,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.7.tgz",
-      "integrity": "sha512-CKdkZbhs+2Mw7M2UZPypKEhKuaF+o5qZB2TQc0pDf+Wr09uEnm6WTdyqzmMGVb5fkQYApu8psQeDyVMbhfoWXQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.8.tgz",
+      "integrity": "sha512-BdH+Or1MjZdoBotz1DkwY6aW3CPWA5fcFMAngmBkviIHhmZqZBn7hA55WQ5YeYbRytct/o2ATtVI/pHbU/wPGg==",
       "dependencies": {
-        "@asyncapi/specs": "^6.5.0",
+        "@asyncapi/specs": "^6.5.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.0.tgz",
-      "integrity": "sha512-84QUcfMT05+vvHO5EnSI0I5OZKzMgF/i3vgw92ghk1l52VM/lb3qNnuARzyo+uHJ9kmIb5+naK9wTuliVOdzmg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.1.tgz",
+      "integrity": "sha512-T7pOyVt7jo3VV3dPVvWwGYde/09WyFa0Qpq8Yjj06UNWJoXACftsdRF/pK0qLtjC0NAB8YV0AlDvxASYiwXq3g==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -9032,11 +9032,11 @@
   },
   "dependencies": {
     "@asyncapi/parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.7.tgz",
-      "integrity": "sha512-CKdkZbhs+2Mw7M2UZPypKEhKuaF+o5qZB2TQc0pDf+Wr09uEnm6WTdyqzmMGVb5fkQYApu8psQeDyVMbhfoWXQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.8.tgz",
+      "integrity": "sha512-BdH+Or1MjZdoBotz1DkwY6aW3CPWA5fcFMAngmBkviIHhmZqZBn7hA55WQ5YeYbRytct/o2ATtVI/pHbU/wPGg==",
       "requires": {
-        "@asyncapi/specs": "^6.5.0",
+        "@asyncapi/specs": "^6.5.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -9087,9 +9087,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.0.tgz",
-      "integrity": "sha512-84QUcfMT05+vvHO5EnSI0I5OZKzMgF/i3vgw92ghk1l52VM/lb3qNnuARzyo+uHJ9kmIb5+naK9wTuliVOdzmg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.1.tgz",
+      "integrity": "sha512-T7pOyVt7jo3VV3dPVvWwGYde/09WyFa0Qpq8Yjj06UNWJoXACftsdRF/pK0qLtjC0NAB8YV0AlDvxASYiwXq3g==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.3",
+    "@asyncapi/parser": "^3.0.4",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.2",
+    "@asyncapi/parser": "^3.0.3",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.8",
+    "@asyncapi/parser": "^3.0.9",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.9",
+    "@asyncapi/parser": "^3.0.10",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.6",
+    "@asyncapi/parser": "^3.0.7",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.4",
+    "@asyncapi/parser": "^3.0.5",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/optimizer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "This library will optimize the AsyncAPI specification file.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.7",
+    "@asyncapi/parser": "^3.0.8",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/parser": "^3.0.5",
+    "@asyncapi/parser": "^3.0.6",
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",

--- a/src/ComponentProvider.ts
+++ b/src/ComponentProvider.ts
@@ -74,6 +74,7 @@ export const getOptimizableComponents = (
     parameters: getAllComponents('parameters'),
     correlationIds: getAllComponents('correlationIds'),
     replies: getAllComponents('replies'),
+    replyAddresses: getAllComponents('replyAddresses'),
     externalDocs: getAllComponents('externalDocs'),
     tags: getAllComponents('tags'),
     operationTraits: getAllComponents('operationTraits'),

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -7,7 +7,7 @@ import {
   Reporter,
 } from './index.d'
 import { Parser } from '@asyncapi/parser'
-import { removeComponents, reuseComponents, moveToComponents } from './Reporters'
+import { removeComponents, reuseComponents, moveDuplicatesToComponents } from './Reporters'
 import YAML from 'js-yaml'
 import merge from 'merge-deep'
 import * as _ from 'lodash'
@@ -42,7 +42,7 @@ export class Optimizer {
    */
   constructor(private YAMLorJSON: any) {
     this.outputObject = toJS(this.YAMLorJSON)
-    this.reporters = [removeComponents, reuseComponents, moveToComponents]
+    this.reporters = [removeComponents, reuseComponents, moveDuplicatesToComponents]
   }
 
   /**
@@ -78,7 +78,7 @@ export class Optimizer {
    * @typedef {Object} Rules
    * @property {Boolean=} reuseComponents - whether to reuse components from `components` section or not. Defaults to `true`.
    * @property {Boolean=} removeComponents - whether to remove un-used components from `components` section or not. Defaults to `true`.
-   * @property {Boolean=} moveToComponents - whether to move duplicated components to the `components` section or not. Defaults to `true`.
+   * @property {Boolean=} moveDuplicatesToComponents - whether to move duplicated components to the `components` section or not. Defaults to `true`.
    */
 
   /**
@@ -98,7 +98,7 @@ export class Optimizer {
       rules: {
         reuseComponents: true,
         removeComponents: true,
-        moveToComponents: true,
+        moveDuplicatesToComponents: true,
       },
       output: Output.YAML,
     }

--- a/src/Reporters/index.ts
+++ b/src/Reporters/index.ts
@@ -1,3 +1,3 @@
-export * from './MoveToComponents'
+export * from './moveDuplicatesToComponents'
 export * from './RemoveComponents'
 export * from './ReuseComponents'

--- a/src/Reporters/moveDuplicatesToComponents.ts
+++ b/src/Reporters/moveDuplicatesToComponents.ts
@@ -2,7 +2,7 @@ import { Action } from '../Optimizer'
 import { createReport, isEqual, isInComponents } from '../Utils'
 import { OptimizableComponent, OptimizableComponentGroup, ReportElement, Reporter } from 'index.d'
 import Debug from 'debug'
-const debug = Debug('reporter:moveToComponents')
+const debug = Debug('reporter:moveDuplicatesToComponents')
 /**
  *
  * @param optimizableComponentGroup components that you want to analyze for duplicates.
@@ -58,8 +58,8 @@ const findDuplicateComponents = (
   return resultElements
 }
 
-export const moveToComponents: Reporter = (optimizableComponentsGroup) => {
-  return createReport(findDuplicateComponents, optimizableComponentsGroup, 'moveToComponents')
+export const moveDuplicatesToComponents: Reporter = (optimizableComponentsGroup) => {
+  return createReport(findDuplicateComponents, optimizableComponentsGroup, 'moveDuplicatesToComponents')
 }
 
 function getOutsideComponents(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export type OptimizableComponentGroup = {
 export interface Report {
   reuseComponents?: ReportElement[]
   removeComponents?: ReportElement[]
-  moveToComponents?: ReportElement[]
+  moveDuplicatesToComponents?: ReportElement[]
 }
 
 //In the next major version we can rename this to `Report` and use this format instead.
@@ -32,7 +32,7 @@ export type Reporter = (optimizeableComponents: OptimizableComponentGroup[]) => 
 interface Rules {
   reuseComponents?: boolean
   removeComponents?: boolean
-  moveToComponents?: boolean
+  moveDuplicatesToComponents?: boolean
 }
 export interface Options {
   rules?: Rules

--- a/test/Reporters/Reporters.spec.ts
+++ b/test/Reporters/Reporters.spec.ts
@@ -1,10 +1,10 @@
-import { moveToComponents, reuseComponents, removeComponents } from '../../src/Reporters'
+import { moveDuplicatesToComponents, reuseComponents, removeComponents } from '../../src/Reporters'
 import { inputYAML } from '../fixtures'
 import { Parser } from '@asyncapi/parser'
 import { getOptimizableComponents } from '../../src/ComponentProvider'
 import { OptimizableComponentGroup } from '../../src/index.d'
 
-const MoveToComponentsExpectedResult: any[] = [
+const moveDuplicatesToComponentsExpectedResult: any[] = [
   {
     path: 'channels.withDuplicatedMessage1.messages.duped1',
     action: 'move',
@@ -55,11 +55,11 @@ describe('Optimizers', () => {
     const asyncapiDocument = await new Parser().parse(inputYAML, { applyTraits: false })
     optimizableComponents = getOptimizableComponents(asyncapiDocument.document!)
   })
-  describe('MoveToComponents', () => {
+  describe('moveDuplicatesToComponents', () => {
     test('should contain the correct optimizations.', () => {
-      const report = moveToComponents(optimizableComponents)
-      expect(report.elements).toEqual(MoveToComponentsExpectedResult)
-      expect(report.type).toEqual('moveToComponents')
+      const report = moveDuplicatesToComponents(optimizableComponents)
+      expect(report.elements).toEqual(moveDuplicatesToComponentsExpectedResult)
+      expect(report.type).toEqual('moveDuplicatesToComponents')
     })
   })
 


### PR DESCRIPTION
This PR renames flag `moveToComponents` -> `moveDuplicatesToComponents`.