### PR TITLE
chore: add @aeworxet and remove @derberg and @magicmatatjahu as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @khudadad414 @magicmatatjahu @derberg @asyncapi-bot-eve
+* @khudadad414 @aeworxet @asyncapi-bot-eve


### PR DESCRIPTION
**Description**

- I propose we add @aeworxet as a code owner. I justify this for the following contribution:
    - #235
    - #216 
    - #215
    - #213
    - #212
- based on [the request](https://github.com/asyncapi/optimizer/pull/252#issuecomment-2061170696) from @derberg I am removing him.
- I assume @magicmatatjahu also wants to remove himself based on @derberg's comment.
