### PR TITLE
fix: update `$ref`s after moving components to `components`

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -11,9 +11,9 @@ const outputFilePath = path.join(__dirname, 'output.yaml')
 const input = fs.readFileSync(inputFilePath, 'utf8')
 const optimizer = new Optimizer(input)
 
-optimizer.getReport().then((report) => {
+optimizer.getReport().then(async (report) => {
   console.log(report)
-  const optimizedDocument = optimizer.getOptimizedDocument({
+  const optimizedDocument = await optimizer.getOptimizedDocument({
     output: 'YAML',
     rules: {
       reuseComponents: true,

--- a/src/Optimizer.ts
+++ b/src/Optimizer.ts
@@ -17,7 +17,7 @@ import YAML from 'js-yaml'
 import merge from 'merge-deep'
 import * as _ from 'lodash'
 import { getOptimizableComponents } from './ComponentProvider'
-import { filterReportElements, hasParent, sortReportElements, toJS } from './Utils'
+import { filterReportElements, hasParent, sortReportElements, toJS, updateExistingRefs } from './Utils'
 import Debug from 'debug'
 
 export enum Action {
@@ -163,6 +163,7 @@ export class Optimizer {
           _.set(this.outputObject, change.path, {
             $ref: `#/${change.target?.replace(/\./g, '/')}`,
           })
+          updateExistingRefs(this.outputObject, change.path, change.target as string)
           debug('moved %s to %s', change.path, change.target)
           break
 

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -169,4 +169,42 @@ const getComponentName = (component: OptimizableComponent): string => {
   return componentName
 }
 
-export { compareComponents, isEqual, isInComponents, isInChannels, toJS, getComponentName }
+function updateExistingRefs(asyncapiComponent: any, changePath: string, changeTarget: string): any {
+  const changePathArray = changePath.split('.')
+  changePathArray.unshift('#')
+  changePath = changePathArray.join('/')
+
+  const changeTargetArray = changeTarget.split('.')
+  changeTargetArray.unshift('#')
+  changeTarget = changeTargetArray.join('/')
+
+  function iterateComponent(asyncapiComponent: any) {
+    // eslint-disable-next-line github/array-foreach
+    Object.values(asyncapiComponent).forEach((key: any) => {
+      if (key && typeof key === 'object' && key !== '$ref') {
+        if (Object.keys(key).indexOf('$ref') !== -1) {
+          const keyValue = key['$ref']
+          if (keyValue.startsWith(`${changePath}/`)) {
+            key['$ref'] = keyValue.replace(changePath, changeTarget)
+          }
+        } else {
+          iterateComponent(key as any)
+        }
+      }
+    })
+  }
+
+  iterateComponent(asyncapiComponent)
+
+  return asyncapiComponent
+}
+
+export {
+  compareComponents,
+  isEqual,
+  isInComponents,
+  isInChannels,
+  toJS,
+  getComponentName,
+  updateExistingRefs,
+}

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -188,7 +188,7 @@ function updateExistingRefs(asyncapiComponent: any, changePath: string, changeTa
             key['$ref'] = keyValue.replace(changePath, changeTarget)
           }
         } else {
-          iterateComponent(key as any)
+          iterateComponent(key)
         }
       }
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface Options {
   rules?: Rules
   output?: Output
   disableOptimizationFor?: DisableOptimizationFor // non-approved type
+  noValidation?: boolean
 }
 
 export interface IOptimizer {

--- a/test/Optimizer.spec.ts
+++ b/test/Optimizer.spec.ts
@@ -18,7 +18,7 @@ describe('Optimizer', () => {
     const optimizer = new Optimizer(inputYAML)
     await optimizer.getReport()
     expect(
-      optimizer
+      await optimizer
         .getOptimizedDocument({
           output: Output.YAML,
           rules: {
@@ -31,7 +31,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCFalse_mDTCTrue_schemaFalse.trim())
   })
 
@@ -52,7 +51,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCFalse_mDTCTrue_schemaFalse.trim())
   })
 
@@ -73,7 +71,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputJSON_mATCFalse_mDTCTrue_schemaFalse.trim())
   })
 
@@ -94,7 +91,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCTrue_mDTCFalse_schemaFalse.trim())
   })
 
@@ -115,7 +111,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCTrue_mDTCFalse_schemaFalse.trim())
   })
 
@@ -136,7 +131,6 @@ describe('Optimizer', () => {
             schema: false,
           },
         })
-        .trim()
     ).toEqual(outputJSON_mATCTrue_mDTCFalse_schemaFalse.trim())
   })
 
@@ -157,7 +151,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCFalse_mDTCTrue_schemaTrue.trim())
   })
 
@@ -178,7 +171,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCFalse_mDTCTrue_schemaTrue.trim())
   })
 
@@ -199,7 +191,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputJSON_mATCFalse_mDTCTrue_schemaTrue.trim())
   })
 
@@ -220,7 +211,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCTrue_mDTCFalse_schemaTrue.trim())
   })
 
@@ -241,7 +231,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputYAML_mATCTrue_mDTCFalse_schemaTrue.trim())
   })
 
@@ -262,7 +251,6 @@ describe('Optimizer', () => {
             schema: true,
           },
         })
-        .trim()
     ).toEqual(outputJSON_mATCTrue_mDTCFalse_schemaTrue.trim())
   })
 })

--- a/test/Reporters/Reporters.spec.ts
+++ b/test/Reporters/Reporters.spec.ts
@@ -7,7 +7,7 @@ import {
 import { inputYAML } from '../fixtures'
 import { Parser } from '@asyncapi/parser'
 import { getOptimizableComponents } from '../../src/ComponentProvider'
-import { OptimizableComponentGroup } from '../../src/index.d'
+import { OptimizableComponentGroup } from '../../src/types'
 
 const moveAllToComponentsExpectedResult: any[] = [
   {


### PR DESCRIPTION
This PR updates `$ref`s of the AsyncAPI Document after moving the AsyncAPI components to the `components` section by prefixing the corresponding JSON Pointers with the characters `components/`.

Addresses issue described in https://github.com/asyncapi/cli/issues/1323#issuecomment-2117488533.