### PR TITLE
fix: update package `jsonpath-plus` to version `10.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/debug": "^4.1.8",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^10.1.0",
         "lodash": "^4.17.21",
         "merge-deep": "^3.0.3",
         "yaml": "^2.3.1"
@@ -1459,6 +1459,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsep-plugin/regex": {
@@ -6499,9 +6510,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
-      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
+      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6556,10 +6567,20 @@
       "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
     },
     "node_modules/jsonpath-plus": {
-      "version": "6.0.1",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -7089,6 +7110,15 @@
       "optionalDependencies": {
         "jsonpath-plus": "^6.0.1",
         "lodash.topath": "^4.5.2"
+      }
+    },
+    "node_modules/nimma/node_modules/jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/debug": "^4.1.8",
     "debug": "^4.3.4",
     "js-yaml": "^4.1.0",
-    "jsonpath-plus": "^6.0.1",
+    "jsonpath-plus": "^10.1.0",
     "lodash": "^4.17.21",
     "merge-deep": "^3.0.3",
     "yaml": "^2.3.1"


### PR DESCRIPTION
This PR updates the NPM package `jsonpath-plus` to version `10.1.0` to close the vulnerability https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884.