### PR TITLE
chore: remove @KhudaDad414 from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @khudadad414 @aeworxet @asyncapi-bot-eve
+* @aeworxet @asyncapi-bot-eve


### PR DESCRIPTION
This PR removes @KhudaDad414 from the `CODEOWNERS` file.